### PR TITLE
Add array support to drizzle zero

### DIFF
--- a/src/drizzle-to-zero.ts
+++ b/src/drizzle-to-zero.ts
@@ -36,7 +36,8 @@ type DrizzleColumnType =
   | "PgJson"
   | "PgNumeric"
   | "PgDateString"
-  | "PgTimestampString";
+  | "PgTimestampString"
+  | "PgArray";
 
 /**
  * Maps Postgres-specific Drizzle column types to their corresponding Zero schema types.
@@ -53,6 +54,7 @@ export const drizzleColumnTypeToZeroType = {
   PgNumeric: "number",
   PgDateString: "number",
   PgTimestampString: "number",
+  PgArray: "json",
 } as const satisfies Record<DrizzleColumnType, string>;
 
 /**

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -107,9 +107,14 @@ type ZeroMappedCustomType<
         data: string;
       }
     ? CD["data"]
-    : CD extends { $type: any }
-      ? CD["$type"]
-      : ZeroTypeToTypescriptType[ZeroMappedColumnType<TTable, KColumn>];
+    : CD extends {
+        columnType: "PgArray";
+        data: infer TArrayData;
+      }
+      ? TArrayData
+      : CD extends { $type: any }
+        ? CD["$type"]
+        : ZeroTypeToTypescriptType[ZeroMappedColumnType<TTable, KColumn>];
 
 /**
  * Defines the structure of a column in the Zero schema.


### PR DESCRIPTION
Add support for Drizzle array types by mapping them to Zero's JSON type.

Previously, Drizzle array types were unsupported, causing warnings and exclusion from the generated schema. This change maps them to Zero's `json` type, a common approach for representing arrays in schema generation while maintaining TypeScript type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-798830d7-28ec-46ce-bca1-62c8c5f241a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-798830d7-28ec-46ce-bca1-62c8c5f241a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

